### PR TITLE
Add plot argument show_cases to overlay squares

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -47,16 +47,17 @@
 #' marks are in ISO 8601 week format yyyy-Www when plotting ISO week-based weekly
 #' incidence; defaults to be TRUE.
 #'
-#' @param episquares if `TRUE` (default: `FALSE`), then each observation will be
-#' colored by a border. The border defaults to a black border unless specified 
+#' @param show_cases if `TRUE` (default: `FALSE`), then each observation will be
+#' colored by a border. The border defaults to a white border unless specified 
 #' otherwise. This is normally used outbreaks with a small number of cases.
+#' Note: this can only be used if `stack = TRUE`
 #'
 #' @param n_breaks the ideal number of breaks to be used for the x-axis
 #'   labeling
 #'
 #' @examples
 #'
-#' if(require(outbreaks)) { withAutoprint({
+#' if(require(outbreaks) && require(ggplot2)) { withAutoprint({
 #'   onset <- ebola_sim$linelist$date_of_onset
 #'
 #'   ## daily incidence
@@ -77,6 +78,15 @@
 #'   plot(inc.week.gender)
 #'   plot(inc.week.gender, labels_iso = FALSE)
 #'
+#'   ## show individual cases at the beginning of the epidemic
+#'   inc.week.8 <- subset(inc.week.gender, to = "2014-06-01")
+#'   plot(inc.week.8, show_cases = TRUE, border = "black")
+#'
+#'   ## customize plot with ggplot2
+#'   plot(inc.week.8, show_cases = TRUE, border = "black") +
+#'     theme_classic(base_size = 16) +
+#'     theme(axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5))
+#'
 #'   ## adding fit
 #'   fit <- fit_optim_split(inc.week.gender)$fit
 #'   plot(inc.week.gender, fit = fit)
@@ -87,7 +97,7 @@ plot.incidence <- function(x, ..., fit = NULL, stack = is.null(fit),
                            color = "black", border = NA, col_pal = incidence_pal1,
                            alpha = .7, xlab = "", ylab = NULL,
                            labels_iso = !is.null(x$isoweeks),
-                           episquares = FALSE,
+                           show_cases = FALSE,
                            n_breaks = 6) {
   stopifnot(is.logical(labels_iso))
 
@@ -159,9 +169,9 @@ plot.incidence <- function(x, ..., fit = NULL, stack = is.null(fit),
                       alpha = alpha) +
     ggplot2::labs(x = xlab, y = ylab)
 
-  ## Handle episquares here
+  ## Handle show_cases here
   
-  if (episquares && stack) {
+  if (show_cases && stack) {
       squaredf <- df[rep(seq.int(nrow(df)), df$counts), ]
       squaredf$counts <- 1
       squares <- ggplot2::geom_bar(ggplot2::aes_string(
@@ -177,8 +187,8 @@ plot.incidence <- function(x, ..., fit = NULL, stack = is.null(fit),
                                    )
       out <- out + squares
   }
-  if (episquares && !stack) {
-    message("episquares requires position to be stack")
+  if (show_cases && !stack) {
+    message("the argument `show_cases` requires the argument `stack = TRUE`")
   }
   ## Handle fit objects here; 'fit' can be either an 'incidence_fit' object,
   ## or a list of these. In the case of a list, we add geoms one after the

--- a/man/plot.incidence.Rd
+++ b/man/plot.incidence.Rd
@@ -10,7 +10,7 @@
 \method{plot}{incidence}(x, ..., fit = NULL, stack = is.null(fit),
   color = "black", border = NA, col_pal = incidence_pal1,
   alpha = 0.7, xlab = "", ylab = NULL,
-  labels_iso = !is.null(x$isoweeks), episquares = FALSE,
+  labels_iso = !is.null(x$isoweeks), show_cases = FALSE,
   n_breaks = 6)
 
 add_incidence_fit(p, x, col_pal = incidence_pal1)
@@ -53,9 +53,10 @@ computation.}
 marks are in ISO 8601 week format yyyy-Www when plotting ISO week-based weekly
 incidence; defaults to be TRUE.}
 
-\item{episquares}{if \code{TRUE} (default: \code{FALSE}), then each observation will be
-colored by a border. The border defaults to a black border unless specified
-otherwise. This is normally used outbreaks with a small number of cases.}
+\item{show_cases}{if \code{TRUE} (default: \code{FALSE}), then each observation will be
+colored by a border. The border defaults to a white border unless specified
+otherwise. This is normally used outbreaks with a small number of cases.
+Note: this can only be used if \code{stack = TRUE}}
 
 \item{n_breaks}{the ideal number of breaks to be used for the x-axis
 labeling}
@@ -68,7 +69,7 @@ function, using the package \code{ggplot2}.
 }
 \examples{
 
-if(require(outbreaks)) { withAutoprint({
+if(require(outbreaks) && require(ggplot2)) { withAutoprint({
   onset <- ebola_sim$linelist$date_of_onset
 
   ## daily incidence
@@ -88,6 +89,15 @@ if(require(outbreaks)) { withAutoprint({
   inc.week.gender <- incidence(onset, interval = 7, groups = sex)
   plot(inc.week.gender)
   plot(inc.week.gender, labels_iso = FALSE)
+
+  ## show individual cases at the beginning of the epidemic
+  inc.week.8 <- subset(inc.week.gender, to = "2014-06-01")
+  plot(inc.week.8, show_cases = TRUE, border = "black")
+
+  ## customize plot with ggplot2
+  plot(inc.week.8, show_cases = TRUE, border = "black") +
+    theme_classic(base_size = 16) +
+    theme(axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5))
 
   ## adding fit
   fit <- fit_optim_split(inc.week.gender)$fit

--- a/man/plot.incidence.Rd
+++ b/man/plot.incidence.Rd
@@ -10,7 +10,8 @@
 \method{plot}{incidence}(x, ..., fit = NULL, stack = is.null(fit),
   color = "black", border = NA, col_pal = incidence_pal1,
   alpha = 0.7, xlab = "", ylab = NULL,
-  labels_iso = !is.null(x$isoweeks), n_breaks = 6)
+  labels_iso = !is.null(x$isoweeks), episquares = FALSE,
+  n_breaks = 6)
 
 add_incidence_fit(p, x, col_pal = incidence_pal1)
 
@@ -51,6 +52,10 @@ computation.}
 \item{labels_iso}{a logical value indicating whether labels x axis tick
 marks are in ISO 8601 week format yyyy-Www when plotting ISO week-based weekly
 incidence; defaults to be TRUE.}
+
+\item{episquares}{if \code{TRUE} (default: \code{FALSE}), then each observation will be
+colored by a border. The border defaults to a black border unless specified
+otherwise. This is normally used outbreaks with a small number of cases.}
 
 \item{n_breaks}{the ideal number of breaks to be used for the x-axis
 labeling}

--- a/tests/figs/deps.txt
+++ b/tests/figs/deps.txt
@@ -3,4 +3,4 @@ FreeType: 2.8.1
 Cairo: 1.15.10
 vdiffr: 0.2.3
 svglite: 1.2.1
-ggplot2: 3.0.0
+ggplot2: 3.1.0

--- a/tests/figs/test-plotting/epiquares-single-plot.svg
+++ b/tests/figs/test-plotting/epiquares-single-plot.svg
@@ -1,0 +1,294 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ=='>
+    <rect x='35.74' y='23.63' width='678.78' height='517.88' />
+  </clipPath>
+</defs>
+<rect x='35.74' y='23.63' width='678.78' height='517.88' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='66.59' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='80.01' y='462.58' width='13.41' height='55.39' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='93.42' y='517.97' width='13.41' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='106.83' y='517.97' width='13.41' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='120.25' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='133.66' y='517.97' width='13.41' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='147.08' y='517.97' width='13.41' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='160.49' y='517.97' width='13.41' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='173.91' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='187.32' y='517.97' width='13.41' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='200.74' y='517.97' width='13.41' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='214.15' y='517.97' width='13.41' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='227.57' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='240.98' y='517.97' width='13.41' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='254.40' y='517.97' width='13.41' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='267.81' y='517.97' width='13.41' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='281.23' y='462.58' width='13.41' height='55.39' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='294.64' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='308.06' y='462.58' width='13.41' height='55.39' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='321.47' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='334.88' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='348.30' y='462.58' width='13.41' height='55.39' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='361.71' y='407.19' width='13.41' height='110.78' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='375.13' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='388.54' y='379.50' width='13.41' height='138.47' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='401.96' y='407.19' width='13.41' height='110.78' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='415.37' y='517.97' width='13.41' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='428.79' y='407.19' width='13.41' height='110.78' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='442.20' y='462.58' width='13.41' height='55.39' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='455.62' y='434.88' width='13.41' height='83.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='469.03' y='324.11' width='13.41' height='193.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='482.45' y='379.50' width='13.41' height='138.47' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='495.86' y='324.11' width='13.41' height='193.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='509.28' y='351.80' width='13.41' height='166.16' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='522.69' y='379.50' width='13.41' height='138.47' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='536.11' y='213.33' width='13.41' height='304.64' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='549.52' y='268.72' width='13.41' height='249.25' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='562.93' y='351.80' width='13.41' height='166.16' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='576.35' y='241.03' width='13.41' height='276.94' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='589.76' y='102.55' width='13.41' height='415.41' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='603.18' y='213.33' width='13.41' height='304.64' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='47.17' width='13.41' height='470.80' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='630.01' y='185.64' width='13.41' height='332.33' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='74.86' width='13.41' height='443.11' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='656.84' y='130.25' width='13.41' height='387.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='670.25' y='213.33' width='13.41' height='304.64' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #000000; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='66.59' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='80.01' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='80.01' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='120.25' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='173.91' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='227.57' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='281.23' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='281.23' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='294.64' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='308.06' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='308.06' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='321.47' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='334.88' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='348.30' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='348.30' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='361.71' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='361.71' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='361.71' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='361.71' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='375.13' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='388.54' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='388.54' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='388.54' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='388.54' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='388.54' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='401.96' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='401.96' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='401.96' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='401.96' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='428.79' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='428.79' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='428.79' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='428.79' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='442.20' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='442.20' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='455.62' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='455.62' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='455.62' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='469.03' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='469.03' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='469.03' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='469.03' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='469.03' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='469.03' y='351.80' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='469.03' y='324.11' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='482.45' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='482.45' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='482.45' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='482.45' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='482.45' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='495.86' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='495.86' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='495.86' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='495.86' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='495.86' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='495.86' y='351.80' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='495.86' y='324.11' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='509.28' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='509.28' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='509.28' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='509.28' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='509.28' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='509.28' y='351.80' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='522.69' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='522.69' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='522.69' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='522.69' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='522.69' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='536.11' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='536.11' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='536.11' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='536.11' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='536.11' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='536.11' y='351.80' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='536.11' y='324.11' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='536.11' y='296.41' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='536.11' y='268.72' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='536.11' y='241.03' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='536.11' y='213.33' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='549.52' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='549.52' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='549.52' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='549.52' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='549.52' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='549.52' y='351.80' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='549.52' y='324.11' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='549.52' y='296.41' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='549.52' y='268.72' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='562.93' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='562.93' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='562.93' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='562.93' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='562.93' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='562.93' y='351.80' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='576.35' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='576.35' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='576.35' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='576.35' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='576.35' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='576.35' y='351.80' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='576.35' y='324.11' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='576.35' y='296.41' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='576.35' y='268.72' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='576.35' y='241.03' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='589.76' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='589.76' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='589.76' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='589.76' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='589.76' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='589.76' y='351.80' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='589.76' y='324.11' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='589.76' y='296.41' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='589.76' y='268.72' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='589.76' y='241.03' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='589.76' y='213.33' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='589.76' y='185.64' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='589.76' y='157.94' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='589.76' y='130.25' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='589.76' y='102.55' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='603.18' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='603.18' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='603.18' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='603.18' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='603.18' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='603.18' y='351.80' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='603.18' y='324.11' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='603.18' y='296.41' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='603.18' y='268.72' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='603.18' y='241.03' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='603.18' y='213.33' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='351.80' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='324.11' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='296.41' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='268.72' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='241.03' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='213.33' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='185.64' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='157.94' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='130.25' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='102.55' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='74.86' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='616.59' y='47.17' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='630.01' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='630.01' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='630.01' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='630.01' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='630.01' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='630.01' y='351.80' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='630.01' y='324.11' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='630.01' y='296.41' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='630.01' y='268.72' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='630.01' y='241.03' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='630.01' y='213.33' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='630.01' y='185.64' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='351.80' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='324.11' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='296.41' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='268.72' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='241.03' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='213.33' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='185.64' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='157.94' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='130.25' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='102.55' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='643.42' y='74.86' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='656.84' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='656.84' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='656.84' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='656.84' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='656.84' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='656.84' y='351.80' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='656.84' y='324.11' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='656.84' y='296.41' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='656.84' y='268.72' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='656.84' y='241.03' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='656.84' y='213.33' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='656.84' y='185.64' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='656.84' y='157.94' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='656.84' y='130.25' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='670.25' y='490.27' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='670.25' y='462.58' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='670.25' y='434.88' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='670.25' y='407.19' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='670.25' y='379.50' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='670.25' y='351.80' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='670.25' y='324.11' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='670.25' y='296.41' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='670.25' y='268.72' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='670.25' y='241.03' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='670.25' y='213.33' width='13.41' height='27.69' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='35.74' y='23.63' width='678.78' height='517.88' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpMzUuNzM2OHw3MTQuNTIxfDU0MS41MDd8MjMuNjI2NQ==)' />
+<defs>
+  <clipPath id='cpMHw3MjB8NTc2fDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='25.91' y='520.99' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='25.91' y='382.52' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='21.02' y='244.05' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='21.02' y='105.58' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text></g>
+<polyline points='33.00,517.97 35.74,517.97 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<polyline points='33.00,379.50 35.74,379.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<polyline points='33.00,241.03 35.74,241.03 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<polyline points='33.00,102.55 35.74,102.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<polyline points='133.66,544.25 133.66,541.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<polyline points='267.81,544.25 267.81,541.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<polyline points='401.96,544.25 401.96,541.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<polyline points='536.11,544.25 536.11,541.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<polyline points='670.25,544.25 670.25,541.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='128.77' y='552.49' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='262.92' y='552.49' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='397.06' y='552.49' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='531.21' y='552.49' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>40</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='665.36' y='552.49' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>50</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text transform='translate(13.05,319.56) rotate(-90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='73.98px' lengthAdjust='spacingAndGlyphs'>Daily incidence</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='35.74' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='121.08px' lengthAdjust='spacingAndGlyphs'>epiquares single plot</text></g>
+</svg>

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -39,6 +39,8 @@ test_that("plot for incidence object", {
   p.optim   <- fit.o$plot
   p.i <- plot(i)
   p.i.cum <- plot(cumulate(i))
+  p.i.square <- plot(i, episquares = TRUE)
+  expect_message(plot(i.sex, episquares = TRUE, stack = FALSE))
 
   p.i.14 <- plot(i.14)
   p.i.2 <- plot(i, color = "blue", alpha = .2)
@@ -78,6 +80,7 @@ test_that("plot for incidence object", {
   vdiffr::expect_doppelganger("incidence fit list plot with split", p.optim.sex.fit)
   vdiffr::expect_doppelganger("split optimum plot", p.optim.sex)
   vdiffr::expect_doppelganger("split optimum plot pooled", p.optim)
+  vdiffr::expect_doppelganger("epiquares single plot", p.i.square)
 
   ## errors
   expect_error(plot(i, fit = "tamere"),

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -39,8 +39,8 @@ test_that("plot for incidence object", {
   p.optim   <- fit.o$plot
   p.i <- plot(i)
   p.i.cum <- plot(cumulate(i))
-  p.i.square <- plot(i, episquares = TRUE)
-  expect_message(plot(i.sex, episquares = TRUE, stack = FALSE))
+  p.i.square <- plot(i, show_cases = TRUE)
+  expect_message(plot(i.sex, show_cases = TRUE, stack = FALSE))
 
   p.i.14 <- plot(i.14)
   p.i.2 <- plot(i, color = "blue", alpha = .2)

--- a/vignettes/customize_plot.Rmd
+++ b/vignettes/customize_plot.Rmd
@@ -216,15 +216,16 @@ p + theme(axis.text.x = element_text(angle = 45, hjust = 1, size = 12),
 
 ### Display individual cases
 
-For small datasets it is convention of EPIET to display individual cases as rectangles. It can be done by doing two things: first setting the background to white and second adding white horizontal and vertical lines to the plot.
+For small datasets it is convention of EPIET to display individual cases as
+rectangles. It can be done by doing two things: first, adding using the option
+`show_cases = TRUE` with a white border and second, setting the background to
+white.
 
-```{r}
-
+```{r, EPIET1}
 i.small <- incidence(onset[160:180])
 
-plot(i.small) +
-  theme(panel.background = element_rect(fill = "white")) +
-  geom_hline(yintercept = seq(max(get_counts(i.small))), color = "white") +
-   geom_vline(xintercept = get_dates(i.small), color = "white") 
-
+plot(i.small, border = "white", show_cases = TRUE) +
+  theme(panel.background = element_rect(fill = "white"))
 ```
+
+


### PR DESCRIPTION
This was a request from the Bulgaria workshop and in general from EPIET folks. @jakobschumacher had contributed an example of how to do this using horizontal lines in the vignette. However, adding this as a single option is best to avoid frustrated epis (as @aspina7 mentioned). Here's what it looks like in practice:

``` r
library(incidence)
library(outbreaks) 
require(ggplot2)
#> Loading required package: ggplot2

onset <- ebola_sim$linelist$date_of_onset
sex <- ebola_sim$linelist$gender
inc.week.gender <- incidence(onset, interval = 7, groups = sex)

## show individual cases at the beginning of the epidemic
inc.week.8 <- subset(inc.week.gender, to = "2014-06-01")

plot(inc.week.8, show_cases = TRUE, border = "black")
```

![](https://i.imgur.com/XiiO0m7.png)

``` r

## customize plot with ggplot2
plot(inc.week.8, show_cases = TRUE, border = "black") +
  theme_classic(base_size = 16) +
  theme(axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5))
```

![](https://i.imgur.com/VLFOP9A.png)

``` r

## a message is issued if the user chooses stack = FALSE
plot(inc.week.8, show_cases = TRUE, stack = FALSE)
#> the argument `show_cases` requires the argument `stack = TRUE`
```

![](https://i.imgur.com/iBDxJhU.png)

<sup>Created on 2018-10-31 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
