### PR TITLE
Allow for single group to not be ignored when plotting or creating data frames

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -21,3 +21,4 @@ README.html
 ^appveyor\.yml$
 bug_reports/*
 ^revdep/
+*_pkgdown.yml

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -21,4 +21,4 @@ README.html
 ^appveyor\.yml$
 bug_reports/*
 ^revdep/
-*_pkgdown.yml
+^_pkgdown.yml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: incidence
 Type: Package
 Title: Compute, Handle, Plot and Model Incidence of Dated Events
-Version: 1.5.2.9000
+Version: 1.5.3
 Authors@R: c(
   person("Thibaut", "Jombart", role = c("aut"), email = "thibautjombart@gmail.com"), 
   person("Zhian N.", "Kamvar", role = c("aut", "cre"), email = "zkamvar@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,17 @@
-incidence 1.5.2.9000
-===========================
+incidence 1.5.3 (2018-12-07)
+============================
 
+### BUG FIX
+
+* `plot.incidence()` will now respect single groups.
+  (See https://github.com/reconhub/incidence/issues/84)
+* `as.data.frame.incidence()` will now respect single groups.
+  (See https://github.com/reconhub/incidence/issues/84)
+
+### MISC
+
+* `demo("incidence-demo" package = "incidenc")` has been updated to show use of
+  custom colors.
 
 incidence 1.5.2 (2018-11-30)
 ============================

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -59,8 +59,10 @@
 #'
 
 as.data.frame.incidence <- function(x, ..., long = FALSE){
-    counts <- x$counts
-    if (ncol(counts) == 1L) {
+    counts  <- x$counts
+    gnames  <- group_names(x)
+    unnamed <- is.null(gnames) && ncol(counts) == 1L
+    if (unnamed) {
         colnames(counts) <- "counts"
     }
 
@@ -73,8 +75,7 @@ as.data.frame.incidence <- function(x, ..., long = FALSE){
     }
 
     ## handle the long format here
-    if (long && ncol(x$counts) > 1) {
-        gnames <- colnames(x$counts)
+    if (long && !unnamed) {
         groups <- factor(rep(gnames, each = nrow(out)), levels = gnames)
         counts <- as.vector(x$counts)
         if ("isoweeks" %in% names(x)) {

--- a/R/plot.R
+++ b/R/plot.R
@@ -104,6 +104,7 @@ plot.incidence <- function(x, ..., fit = NULL, stack = is.null(fit),
   ## extract data in suitable format for ggplot2
   df <- as.data.frame(x, long = TRUE)
   n.groups <- ncol(x$counts)
+  gnames   <- group_names(x)
 
   ## Use custom labels for usual time intervals
   if (is.null(ylab)) {
@@ -225,12 +226,28 @@ plot.incidence <- function(x, ..., fit = NULL, stack = is.null(fit),
   ## by default, the palette is used, but the user can manually specify the
   ## colors.
 
-  if (ncol(x$counts) < 2) {
+  if (n.groups < 2 && is.null(gnames)) {
     out <- out + ggplot2::aes(fill = 'a') +
       ggplot2::scale_fill_manual(values = color, guide = FALSE)
   } else {
+    if (!is.null(names(color))) {
+      tmp     <- color[gnames] 
+      matched <- names(color) %in% names(tmp)
+      if (!all(matched)) {
+        removed <- paste(names(color)[!matched], collapse = ", ")
+        message(sprintf("%d colors were not used: %s", length(removed), removed))
+      }
+      color <- tmp
+    }
+                                 
     ## find group colors
-    if (length(color) != ncol(x$counts)) {
+    if (length(color) != n.groups) {
+      msg <- "The number of colors (%d) did not match the number of groups (%d)"
+      msg <- paste0(msg, ".\nUsing `col_pal` instead.")
+      default_color <- length(color) == 1L && color == "black"
+      if (!default_color) {
+        message(sprintf(msg, length(color), n.groups))
+      }
       group.colors <- col_pal(n.groups)
     } else {
       group.colors <- color

--- a/R/plot.R
+++ b/R/plot.R
@@ -234,8 +234,11 @@ plot.incidence <- function(x, ..., fit = NULL, stack = is.null(fit),
       tmp     <- color[gnames] 
       matched <- names(color) %in% names(tmp)
       if (!all(matched)) {
-        removed <- paste(names(color)[!matched], collapse = ", ")
-        message(sprintf("%d colors were not used: %s", length(removed), removed))
+        removed <- paste(names(color)[!matched], 
+                         color[!matched],
+                         sep = '" = "',
+                         collapse = '", "')
+        message(sprintf("%d colors were not used: \"%s\"", sum(!matched), removed))
       }
       color <- tmp
     }

--- a/R/print.R
+++ b/R/print.R
@@ -9,7 +9,7 @@ print.incidence <- function(x, ...) {
     cat(sprintf("[%d cases from ISO weeks %s to %s]\n",
                 sum(x$n), head(x$isoweeks, 1), tail(x$isoweeks, 1)))
   }
-  if (ncol(x$counts) > 1L) {
+  if (!is.null(group_names(x))) {
     groups.txt <- paste(group_names(x), collapse = ", ")
     cat(sprintf("[%d groups: %s]\n", ncol(x), groups.txt))
   }

--- a/demo/incidence-demo.R
+++ b/demo/incidence-demo.R
@@ -32,8 +32,8 @@ plot(i.7.group, border = "white") +
 #' 3) Manipulate incidence object
 #'
 #+ incidence-early-curve, fig.width=6, fig.height=6
-# plot the first 15 weeks, defined hospitals, and use different colors
-i.7.sub <- i.7.group[1:15, c(1:2, 4:5)]
+# plot the first 18 weeks, defined hospitals, and use different colors
+i.7.sub <- i.7.group[1:18, c(1:2, 4:5)]
 hosp_colors <- c("#899DA4", "#C93312", "#FAEFD1", "#DC863B")
 plot(i.7.sub, show_cases = TRUE, border = "black", color = hosp_colors) + 
   my_theme +

--- a/demo/incidence-demo.R
+++ b/demo/incidence-demo.R
@@ -16,31 +16,31 @@ library('incidence')
 library('ggplot2')
 
 # compute weekly stratified incidence
-i.7.group <- incidence(dat1$date_of_onset,
-                       interval = 7L,
-                       groups   = dat1$hospital)
+i.7.group <- incidence(dat1$date_of_onset, interval = 7, groups = dat1$hospital)
 # print incidence object
 i.7.group
 
 # plot incidence object
 my_theme <- theme_bw(base_size = 12) +
-  theme(legend.position = c(.8, .7)) +
   theme(panel.grid.minor = element_blank()) +
-  theme(axis.text = element_text(color = "black"))
-plot(i.7.group, border = "white") + my_theme
+  theme(axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5, color = "black"))
+
+plot(i.7.group, border = "white") + 
+  my_theme + 
+  theme(legend.position = c(0.8, 0.75))
 
 #' 3) Manipulate incidence object
 #'
-#+ incidence-early-curve, fig.width=6, fig.height=7
-# plot the first 8 weeks
-plot(i.7.group[1:8, ], show_cases = TRUE) +
-  theme_bw(base_size = 12) +
-  theme(axis.text.x = element_text(angle = 90, hjust = 1, color = "black")) +
-  theme(panel.grid.minor = element_blank())
-
+#+ incidence-early-curve, fig.width=6, fig.height=6
+# plot the first 15 weeks, defined hospitals, and use different colors
+i.7.sub <- i.7.group[1:15, c(1:2, 4:5)]
+hosp_colors <- c("#899DA4", "#C93312", "#FAEFD1", "#DC863B")
+plot(i.7.sub, show_cases = TRUE, border = "black", color = hosp_colors) + 
+  my_theme +
+  theme(legend.position = c(0.35, 0.8)) 
 # exclude NA group by disabling treating NA as a separate group
 i.7.group0 <- incidence(dat1$date_of_onset,
-                        interval    = 7L,
+                        interval    = 7,
                         groups      = dat1$hospital,
                         na_as_group = FALSE)
 
@@ -63,7 +63,7 @@ colnames(i.7.group1$counts)
 #'
 #' 1) Import pre-computed daily incidence
 #'
-#+ incidence-curve2, fig.width=9, fig.height=5
+#+ incidence-curve2, fig.width=9, fig.height=6
 # preview datasets
 head(zika_girardot_2015, 3)
 head(zika_sanandres_2015, 3)
@@ -84,7 +84,7 @@ i.group <- as.incidence(x = dat2[, 2:3], dates = dat2$date)
 # pool incidence across two locations
 i.pooled <- pool(i.group)
 cowplot::plot_grid(
-	plot(i.group, border = "white")  + my_theme,
+	plot(i.group, border = "white")  + my_theme + theme(legend.position = c(0.9, 0.7)),
 	plot(i.pooled, border = "white") + my_theme,
 	ncol       = 1,
 	labels     = c("(A)", "(B)"),

--- a/tests/figs/test-plotting/grouped-incidence-plot-with-one-group.svg
+++ b/tests/figs/test-plotting/grouped-incidence-plot-with-one-group.svg
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ=='>
+    <rect x='35.74' y='23.63' width='606.04' height='517.88' />
+  </clipPath>
+</defs>
+<rect x='35.74' y='23.63' width='606.04' height='517.88' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='63.28' y='490.27' width='11.98' height='27.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='75.26' y='462.58' width='11.98' height='55.39' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='87.24' y='517.97' width='11.98' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='99.22' y='517.97' width='11.98' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='111.19' y='490.27' width='11.98' height='27.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='123.17' y='517.97' width='11.98' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='135.15' y='517.97' width='11.98' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='147.12' y='517.97' width='11.98' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='159.10' y='490.27' width='11.98' height='27.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='171.08' y='517.97' width='11.98' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='183.05' y='517.97' width='11.98' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='195.03' y='517.97' width='11.98' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='207.01' y='490.27' width='11.98' height='27.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='218.99' y='517.97' width='11.98' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='230.96' y='517.97' width='11.98' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='242.94' y='517.97' width='11.98' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='254.92' y='462.58' width='11.98' height='55.39' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='266.89' y='490.27' width='11.98' height='27.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='278.87' y='462.58' width='11.98' height='55.39' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='290.85' y='490.27' width='11.98' height='27.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='302.83' y='490.27' width='11.98' height='27.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='314.80' y='462.58' width='11.98' height='55.39' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='326.78' y='407.19' width='11.98' height='110.78' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='338.76' y='490.27' width='11.98' height='27.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='350.73' y='379.50' width='11.98' height='138.47' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='362.71' y='407.19' width='11.98' height='110.78' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='374.69' y='517.97' width='11.98' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='386.66' y='407.19' width='11.98' height='110.78' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='398.64' y='462.58' width='11.98' height='55.39' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='410.62' y='434.88' width='11.98' height='83.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='422.60' y='324.11' width='11.98' height='193.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='434.57' y='379.50' width='11.98' height='138.47' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='446.55' y='324.11' width='11.98' height='193.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='458.53' y='351.80' width='11.98' height='166.16' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='470.50' y='379.50' width='11.98' height='138.47' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='482.48' y='213.33' width='11.98' height='304.64' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='494.46' y='268.72' width='11.98' height='249.25' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='506.44' y='351.80' width='11.98' height='166.16' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='518.41' y='241.03' width='11.98' height='276.94' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='530.39' y='102.55' width='11.98' height='415.41' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='542.37' y='213.33' width='11.98' height='304.64' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='554.34' y='47.17' width='11.98' height='470.80' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='566.32' y='185.64' width='11.98' height='332.33' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='578.30' y='74.86' width='11.98' height='443.11' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='590.28' y='130.25' width='11.98' height='387.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='602.25' y='213.33' width='11.98' height='304.64' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<rect x='35.74' y='23.63' width='606.04' height='517.88' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpMzUuNzM2OHw2NDEuNzc2fDU0MS41MDd8MjMuNjI2NQ==)' />
+<defs>
+  <clipPath id='cpMHw3MjB8NTc2fDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='25.91' y='520.99' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='25.91' y='382.52' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='21.02' y='244.05' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='21.02' y='105.58' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text></g>
+<polyline points='33.00,517.97 35.74,517.97 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<polyline points='33.00,379.50 35.74,379.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<polyline points='33.00,241.03 35.74,241.03 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<polyline points='33.00,102.55 35.74,102.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<polyline points='123.17,544.25 123.17,541.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<polyline points='242.94,544.25 242.94,541.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<polyline points='362.71,544.25 362.71,541.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<polyline points='482.48,544.25 482.48,541.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<polyline points='602.25,544.25 602.25,541.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='118.28' y='552.49' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='238.05' y='552.49' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='357.82' y='552.49' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='477.59' y='552.49' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>40</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='597.36' y='552.49' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>50</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text transform='translate(13.05,319.56) rotate(-90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='73.98px' lengthAdjust='spacingAndGlyphs'>Daily incidence</text></g>
+<rect x='653.12' y='266.16' width='61.41' height='32.82' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='653.12' y='274.97' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='33.63px' lengthAdjust='spacingAndGlyphs'>groups</text></g>
+<rect x='653.12' y='281.70' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<rect x='653.82' y='282.40' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linejoin: miter; fill: #0000FF; fill-opacity: 0.70;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='675.87' y='293.36' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='38.65px' lengthAdjust='spacingAndGlyphs'>this group</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='35.74' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='223.09px' lengthAdjust='spacingAndGlyphs'>grouped incidence plot with one group</text></g>
+</svg>

--- a/tests/testthat/test-conversions.R
+++ b/tests/testthat/test-conversions.R
@@ -6,7 +6,9 @@ test_that("as.data.frame works", {
   dat <- as.integer(c(0,1,2,2,3,5,7))
   dat2 <- as.Date("2016-01-02") + dat
   fac <- factor(c(1, 2, 3, 3, 3, 3, 1))
+  one_group <- rep("a", 7)
   i <- incidence(dat, groups = fac)
+  iog <- incidence(dat, groups = one_group)
   i.7 <- incidence(dat2, 7L, standard = TRUE)
   i.7.group <- incidence(dat2, 7L, standard = TRUE, groups = fac)
   df  <- as.data.frame(i)
@@ -16,6 +18,8 @@ test_that("as.data.frame works", {
   df4 <- as.data.frame(i.7, long = TRUE)
   df5 <- as.data.frame(i.7.group)
   df6 <- as.data.frame(i.7.group, long = TRUE)
+  df7 <- as.data.frame(iog)
+  df8 <- as.data.frame(iog, long = TRUE)
 
   expect_equal_to_reference(df, file = "rds/df.rds")
   expect_equal_to_reference(dfl, file = "rds/dfl.rds")
@@ -24,6 +28,8 @@ test_that("as.data.frame works", {
   expect_equal(df3, df4)
   expect_equal_to_reference(df5, file = "rds/df5.rds")
   expect_equal_to_reference(df6, file = "rds/df6.rds")
+  expect_named(df7, c("dates", "a"))
+  expect_named(df8, c("dates", "counts", "groups"))
 })
 
 test_that("as.incidence works", {

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -15,6 +15,7 @@ test_that("plot for incidence object", {
 
   # constructing data
   i <- incidence(dat)
+  iog <- incidence(dat, groups = rep("this group", 200))
   i.3 <- incidence(dat, 3L)
   i.14 <- incidence(dat, 14L)
   i.sex <- incidence(dat, 7L, groups = sex)
@@ -44,6 +45,7 @@ test_that("plot for incidence object", {
 
   p.i.14 <- plot(i.14)
   p.i.2 <- plot(i, color = "blue", alpha = .2)
+  expect_message(p.iog <- plot(iog, color = c("this group" = "blue", "that group" = "red")), "1 colors were not used: \"that group\" = \"red\"")
   p.i.3 <- plot(i.3, fit = fit.i.3, color = "red")
   p.sex <- plot(i.sex)
   p.sex.cum <- plot(cumulate(i.sex))
@@ -67,6 +69,7 @@ test_that("plot for incidence object", {
   vdiffr::expect_doppelganger("incidence plot with specified color and alpha", p.i.2)
   vdiffr::expect_doppelganger("incidence plot with interval of 3 days, fit and specified color", p.i.3)
   vdiffr::expect_doppelganger("grouped incidence plot", p.sex)
+  vdiffr::expect_doppelganger("grouped incidence plot with one group", p.iog)
   vdiffr::expect_doppelganger("grouped incidence plot, cumulative", p.sex.cum)
   vdiffr::expect_doppelganger("grouped incidence plot with fit", p.sex.2)
   vdiffr::expect_doppelganger("grouped incidence plot with color palette", p.sex.3)

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -40,7 +40,7 @@ test_that("plot for incidence object", {
   p.i <- plot(i)
   p.i.cum <- plot(cumulate(i))
   p.i.square <- plot(i, show_cases = TRUE)
-  expect_message(plot(i.sex, show_cases = TRUE, stack = FALSE))
+  expect_message(plot(i.sex, show_cases = TRUE, stack = FALSE), "`show_cases` requires the argument `stack = TRUE`")
 
   p.i.14 <- plot(i.14)
   p.i.2 <- plot(i, color = "blue", alpha = .2)


### PR DESCRIPTION
Currently, if there is only a single grouping variable, the plotting and conversion are treated as if no groups exist. This is erroneous because if the user specifies a group in the incidence call, it should be respected. 

This PR will fix #84 and this behavior in three ways:

1. `as.data.frame()` will return the column name instead of `counts` and will add a `groups` column when `long = TRUE`. 
2. `plot()` will respect single groups
2. `plot()` will inform users if there were colors not used

``` r
library("incidence")
library("ggplot2")
i <- incidence(rpois(100, 5), groups = rep("look!", 100))
my_colors <- c("at" = "blue", "this" = "pink", "look!" = "purple")
plot(i, color = my_colors)
#> 2 colors were not used: "at" = "blue", "this" = "pink"
```

![](https://i.imgur.com/pQIjNoT.png)

``` r
# From issue #84
plot(i) + scale_fill_manual(name = "Hey!", values = my_colors)
#> Scale for 'fill' is already present. Adding another scale for 'fill',
#> which will replace the existing scale.
```

![](https://i.imgur.com/M3s3NPG.png)

<sup>Created on 2018-12-07 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

--------

I still need to write tests for this, but the basic machinery is there. Thanks again to @pbkeating for pointing this out!