### PR TITLE
Prioritise standard

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: incidence
 Type: Package
 Title: Compute, Handle, Plot and Model Incidence of Dated Events
-Version: 1.5.4.99
-Date: 2019-02-23
+Version: 1.6.0
+Date: 2019-03-05
 Authors@R: c(
   person("Thibaut", "Jombart", role = c("aut"), email = "thibautjombart@gmail.com"), 
   person("Zhian N.", "Kamvar", role = c("aut", "cre"), email = "zkamvar@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
-incidence 1.5.4.99 unreleased
+incidence 1.6.0 unreleased
 ============================
+
+### BEHAVIORAL CHANGE
+
+* `incidence()` will no longer allow a non-standard `first_date` to override
+  `standard = TRUE. The first call to `incidence()` specifying `first_date` 
+  without `standard` will issue a warning. To use non-standard first dates, 
+  specify `standard = FALSE`. To remove the warning, use
+  `options(incidence.warn.first_date = FALSE)`. See
+  https://github.com/reconhub/incidence/issues/87 for details.  
+
+### CITATION ADDED
+
+* `citation("incidence")` will now give the proper citation for our article in
+  F1000 research and the global DOI for archived code. 
 
 
 incidence 1.5.4 (2019-01-15)

--- a/R/incidence.R
+++ b/R/incidence.R
@@ -165,13 +165,13 @@
 #' d <- Sys.Date() + sample(-3:10, 10, replace = TRUE)
 #' 
 #' # `standard` specified, no warning
-#' di <- incidence(d, first_date = Sys.Date() - 10, standard = TRUE)
+#' di <- incidence(d, interval = "week", first_date = Sys.Date() - 10, standard = TRUE)
 #'
 #' # warning issued if `standard` not specified
-#' di <- incidence(d, first_date = Sys.Date() - 10)
+#' di <- incidence(d, interval = "week", first_date = Sys.Date() - 10)
 #'
-#' # secon instance: no warning issued
-#' di <- incidence(d, first_date = Sys.Date() - 10)
+#' # second instance: no warning issued
+#' di <- incidence(d, interval = "week", first_date = Sys.Date() - 10)
 #'
 #'
 incidence <- function(dates, interval = 1L, ...) {

--- a/R/make_breaks.R
+++ b/R/make_breaks.R
@@ -9,8 +9,6 @@
 #' @param last_date an integer, numeric, or Date
 #' @param first_date an integer, numeric, or Date
 #' @param dots a named list of options
-#' @param null_first_date a logical specifying whether or not the first_date
-#'   argument was NULL in the original call.
 #'
 #' @author Zhian Kamvar
 #' @return a vector of integers or Dates
@@ -21,8 +19,7 @@
 #' d <- sample(10, replace = TRUE)
 #' make_breaks_easier(d, 2L)
 make_breaks_easier <- function(dates, the_interval, first_date = NULL,
-                               last_date = NULL, dots = 1L,
-                               null_first_date = TRUE) {
+                               last_date = NULL, dots = 1L) {
 
   the_interval    <- valid_interval_character(the_interval)
   date_interval   <- is.character(the_interval) && is_date_interval(the_interval)
@@ -34,7 +31,7 @@ make_breaks_easier <- function(dates, the_interval, first_date = NULL,
   the_month <- as.integer(substr(fd, 6, 7))
 
   if ("standard" %in% names(dots)) {
-    if (isTRUE(dots$standard) && null_first_date) {
+    if (isTRUE(dots$standard)) {
       is_a_week <- !uneven_interval && check_week(the_interval)
       if (is_a_week) {
         # This returns something like 2018-W29-2, where the last digit indicates

--- a/R/make_incidence.R
+++ b/R/make_incidence.R
@@ -35,16 +35,14 @@ make_incidence <- function(dates, interval = 1L, groups = NULL,
   groups   <- check_groups(groups, dates, na_as_group)
 
   ## Check the interval and arrange the breaks
-  null_first_date <- is.null(first_date)
-  first_date      <- check_boundaries(dates, first_date, "first")
-  last_date       <- check_boundaries(dates, last_date, "last")
-  breaks          <- make_breaks_easier(dates,
-                                        the_interval    = interval,
-                                        first_date      = first_date,
-                                        last_date       = last_date,
-                                        dots            = dots,
-                                        null_first_date = null_first_date
-                                        )
+  first_date <- check_boundaries(dates, first_date, "first")
+  last_date  <- check_boundaries(dates, last_date, "last")
+  breaks     <- make_breaks_easier(dates,
+                                   the_interval    = interval,
+                                   first_date      = first_date,
+                                   last_date       = last_date,
+                                   dots            = dots
+                                   )
 
   ## Trim the dates and groups as necessary
   trimmed <- trim_observations(dates, first_date, last_date)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,7 @@
 .onLoad <- function(...) {
   op <- options()
-  op.incidence <- list(incidence.max.days = 18262)
+  op.incidence <- list(incidence.max.days = 18262,
+                      incidence.warn.first_date = TRUE)
   toset <- !names(op.incidence) %in% op
   if (any(toset)) options(op.incidence[toset])
 }

--- a/man/incidence.Rd
+++ b/man/incidence.Rd
@@ -171,13 +171,13 @@ if(require(outbreaks)) { withAutoprint({
 d <- Sys.Date() + sample(-3:10, 10, replace = TRUE)
 
 # `standard` specified, no warning
-di <- incidence(d, first_date = Sys.Date() - 10, standard = TRUE)
+di <- incidence(d, interval = "week", first_date = Sys.Date() - 10, standard = TRUE)
 
 # warning issued if `standard` not specified
-di <- incidence(d, first_date = Sys.Date() - 10)
+di <- incidence(d, interval = "week", first_date = Sys.Date() - 10)
 
-# secon instance: no warning issued
-di <- incidence(d, first_date = Sys.Date() - 10)
+# second instance: no warning issued
+di <- incidence(d, interval = "week", first_date = Sys.Date() - 10)
 
 
 }

--- a/man/incidence.Rd
+++ b/man/incidence.Rd
@@ -50,7 +50,7 @@ month, quarter, or year. (See Note)}
 \item{standard}{(Only applicable to Date objects) When \code{TRUE} (default) and the
 \code{interval} one of "week", "month", "quarter", or "year", then this will
 cause the bins for the counts to start at the beginning of the interval
-(See Note). This is overridden by defining a non-NULL \code{first_date}.}
+(See Note).}
 
 \item{groups}{An optional factor defining groups of observations for which
 incidence should be computed separately.}
@@ -116,11 +116,16 @@ Wednesday, 2018-05-09:
 \item "year"    : first day of the calendar year (i.e. 2018-01-01)
 }
 
-These default intervals can be overridden in two ways:
-\enumerate{
-\item Specify \code{standard = FALSE}, which sets the interval to begin at the first
-observed case.
-\item Specify a date in the \code{first_date} field.
+These default intervals can be overridden with \code{standard = FALSE}, which
+sets the interval to begin at the first observed case.
+
+\subsection{The \code{first_date} argument}{
+Previous versions of \emph{incidence} had the \code{first_date} argument override
+\code{standard = TRUE}. It has been changed as of \emph{incidence} version 1.6.0 to
+be more consistent with the behavior when \code{first_date = NULL}. This, however
+may be a change in behaviour, so a warning is now issued once and only once
+if \code{first_date} is specified, but \code{standard} is not. To never see this
+warning, use \code{options(incidence.warn.first_date = FALSE)}.
 }
 
 The intervals for "month", "quarter", and "year" will necessarily vary in the
@@ -136,7 +141,7 @@ incidence(c(1, 5, 8, 3, 7, 2, 4, 6, 9, 2), 2)
 
 ## example using simulated dataset
 if(require(outbreaks)) { withAutoprint({
-  onset <- ebola_sim$linelist$date_of_onset
+  onset <- outbreaks::ebola_sim$linelist$date_of_onset
 
   ## daily incidence
   inc <- incidence(onset)
@@ -161,6 +166,18 @@ if(require(outbreaks)) { withAutoprint({
                                   groups = sex, standard = TRUE)
   inc.isoweek.gender
 })}
+
+# Use of first_date
+d <- Sys.Date() + sample(-3:10, 10, replace = TRUE)
+
+# `standard` specified, no warning
+di <- incidence(d, first_date = Sys.Date() - 10, standard = TRUE)
+
+# warning issued if `standard` not specified
+di <- incidence(d, first_date = Sys.Date() - 10)
+
+# secon instance: no warning issued
+di <- incidence(d, first_date = Sys.Date() - 10)
 
 
 }

--- a/tests/testthat/test-incidence.R
+++ b/tests/testthat/test-incidence.R
@@ -160,7 +160,7 @@ test_that("construction - Date input", {
   )
   x.yr.iso <- incidence(dat.yr, "year")
   x.yr     <- incidence(dat.yr, "year", standard = FALSE)
-  expect_warning(x.yr.no  <- incidence(dat.yr, "year", first_date = as.Date("2016-02-29")),
+  expect_warning(x.yr.no  <- incidence(dat.yr, "year", first_date = as.Date("2016-02-29"), standard = FALSE),
                  "The first_date \\(2016-02-29\\) represents a day that does not occur in all years."
   )
   expect_equal(get_dates(x.yr.iso), as.Date(c("2015-01-01", "2016-01-01", "2017-01-01", "2018-01-01")))

--- a/tests/testthat/test-incidence.R
+++ b/tests/testthat/test-incidence.R
@@ -107,9 +107,16 @@ test_that("construction - Date input", {
   expect_message(x.i.trim  <- incidence(dat, first_date = 0),
                  "[0-9]+ observations outside of \\[0, [0-9]+\\] were removed."
   )
-  expect_message(x.d.trim  <- incidence(dat_dates, first_date = "2016-01-01"),
-                 "[0-9]+ observations outside of \\[2016-01-01, [-0-9]{10}\\] were removed."
-  )
+  expect_warning({
+  expect_message({
+    x.d.trim  <- incidence(dat_dates, first_date = "2016-01-01")
+  }, "[0-9]+ observations outside of \\[2016-01-01, [-0-9]{10}\\] were removed.")
+  }, "options\\(incidence.warn.first_date = FALSE\\)")
+  expect_message({
+  expect_failure(expect_warning({
+    x.d.trim  <- incidence(dat_dates, first_date = "2016-01-01")
+  }, "options\\(incidence.warn.first_date = FALSE\\)"))
+  }, "[0-9]+ observations outside of \\[2016-01-01, [-0-9]{10}\\] were removed.")
   x.7       <- incidence(dat_dates, 7L, standard = FALSE)
   x.7.iso   <- incidence(dat_dates, "week")
   x.7.week  <- incidence(dat_dates, "week", standard = FALSE)

--- a/tests/testthat/test-standards.R
+++ b/tests/testthat/test-standards.R
@@ -1,0 +1,21 @@
+context("standardisation tests") 
+
+
+d <- c('2019-04-18', '2019-04-14', '2019-03-31', '2019-04-03', '2019-03-30',
+       '2019-04-05', '2019-03-12', '2019-04-07', '2019-04-02', '2019-03-09',
+       '2019-04-20', '2019-04-23', '2019-03-07', '2019-03-25', '2019-03-27',
+       '2019-04-13', '2019-04-15', '2019-04-04', '2019-03-30', '2019-03-19')
+
+test_that("standard will override first_date", {
+       
+  expect_output(print(incidence(d, interval = "week", standard = TRUE)), "2019-03-04")       
+  expect_output(print(incidence(d, interval = "week", standard = TRUE)), "2019-W10")       
+  expect_output(print(incidence(d, interval = "week", standard = FALSE)), "2019-03-07")       
+
+  expect_output(print(incidence(d, interval = "month", standard = TRUE)), "2019-03-01")       
+  expect_output(print(incidence(d, interval = "month", standard = FALSE)), "2019-03-07")       
+       
+  expect_output(print(incidence(d, interval = "year", standard = TRUE)), "2019-01-01")       
+  expect_output(print(incidence(d, interval = "year", standard = FALSE)), "2019-03-07")       
+       
+})


### PR DESCRIPTION
This will fix #87 

 - `first_date` no longer overrides `standard = TRUE`
 - a one-time warning is issued if the user uses `incidence()` with `first_date`, but not `standard`
 - specific tests added

``` r
library("incidence")
d <- Sys.Date() + sample(-3:10, 10, replace = TRUE)
Sys.Date() - 10
#> [1] "2019-02-23"
```

`standard` specified, no warning

``` r
incidence(d, interval = "week", first_date = Sys.Date() - 10, standard = TRUE)
#> <incidence object>
#> [10 cases from days 2019-02-18 to 2019-03-11]
#> [10 cases from ISO weeks 2019-W08 to 2019-W11]
#> 
#> $counts: matrix with 4 rows and 1 columns
#> $n: 10 cases in total
#> $dates: 4 dates marking the left-side of bins
#> $interval: 1 week
#> $timespan: 22 days
#> $cumulative: FALSE
```

warning issued if `standard` not specified

``` r
incidence(d, interval = "week", first_date = Sys.Date() - 10)
#> Warning in incidence.Date(d, interval = "week", first_date = Sys.Date() - : 
#> 
#> As of incidence version 1.6.0, the default behavior has been modified so that `first_date` no longer overrides `standard`. If you want to use Sys.Date() - 10 as the precise `first_date`, set `standard = FALSE`.
#> 
#> To remove this warning in the future,  explicitly set the `standard` argument OR use `options(incidence.warn.first_date = FALSE)`
#> <incidence object>
#> [10 cases from days 2019-02-18 to 2019-03-11]
#> [10 cases from ISO weeks 2019-W08 to 2019-W11]
#> 
#> $counts: matrix with 4 rows and 1 columns
#> $n: 10 cases in total
#> $dates: 4 dates marking the left-side of bins
#> $interval: 1 week
#> $timespan: 22 days
#> $cumulative: FALSE
```

second instance: no warning issued

``` r
incidence(d, interval = "week", first_date = Sys.Date() - 10)
#> <incidence object>
#> [10 cases from days 2019-02-18 to 2019-03-11]
#> [10 cases from ISO weeks 2019-W08 to 2019-W11]
#> 
#> $counts: matrix with 4 rows and 1 columns
#> $n: 10 cases in total
#> $dates: 4 dates marking the left-side of bins
#> $interval: 1 week
#> $timespan: 22 days
#> $cumulative: FALSE
```

<sup>Created on 2019-03-05 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>