### PR TITLE
Patch issue 119 (broken plots) 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: incidence
 Type: Package
 Title: Compute, Handle, Plot and Model Incidence of Dated Events
-Version: 1.7.0
+Version: 1.7.1
 Date: 2019-03-14
 Authors@R: c(
   person("Thibaut", "Jombart", role = c("aut"), email = "thibautjombart@gmail.com"), 
@@ -20,7 +20,7 @@ Encoding: UTF-8
 License: MIT + file LICENSE
 URL: http://www.repidemicsconsortium.org/incidence/
 BugReports: http://github.com/reconhub/incidence/issues
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 Imports:
     ggplot2, 
     aweek (>= 0.2.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Encoding: UTF-8
 License: MIT + file LICENSE
 URL: http://www.repidemicsconsortium.org/incidence/
 BugReports: http://github.com/reconhub/incidence/issues
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Imports:
     ggplot2, 
     aweek (>= 0.2.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,16 @@
-incidence 1.7.0
+
+incidence 1.7.1
+============================
+
+### BUG FIXES
+
+* Fix for a [bug in](https://github.com/reconhub/incidence/issues/119) `plot.incidence` 
+introduced with new release of *ggplot2* ([bug report](https://github.com/tidyverse/ggplot2/issues/3873))
+
+
+
+
+incidence 1.7.0 
 ============================
 
 ### NEW FEATURES

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -72,10 +72,10 @@ as.data.frame.incidence <- function(x, ..., long = FALSE){
                         weeks = as.character(x$weeks),
                         isoweeks = as.character(x$weeks),
                         counts,
-                        check.names = FALSE)
+                        check.names = FALSE, stringsAsFactors = TRUE)
       out$weeks <- aweek::date2week(out$dates, ws, floor_day = TRUE, factor = TRUE)
     } else {
-      out <- data.frame(dates = x$dates, counts, check.names = FALSE)
+      out <- data.frame(dates = x$dates, counts, check.names = FALSE, stringsAsFactors = TRUE)
     }
 
     ## handle the long format here
@@ -88,13 +88,13 @@ as.data.frame.incidence <- function(x, ..., long = FALSE){
                             isoweeks = out$isoweeks,
                             counts = counts,
                             groups = groups,
-                            check.names = FALSE)
+                            check.names = FALSE, stringsAsFactors = TRUE)
           out$weeks <- aweek::date2week(out$dates, ws, floor_day = TRUE, factor = TRUE)
         } else {
           out <- data.frame(dates = out$dates,
                             counts = counts,
                             groups = groups,
-                            check.names = FALSE)
+                            check.names = FALSE, stringsAsFactors = TRUE)
         }
     }
     if (all(names(x) != "isoweeks")) out$isoweeks <- NULL
@@ -138,7 +138,7 @@ as.incidence <- function(x, ...) {
 #'
 #' @param standard A logical indicating whether standardised dates should be
 #'   used. Defaults to `TRUE`.
-#' 
+#'
 #' @param isoweeks Deprecated. Use standard.
 #'
 

--- a/R/fit.R
+++ b/R/fit.R
@@ -69,7 +69,7 @@
 #' be fitted on the time periods on either side of the split.
 #'
 #' @param level The confidence interval to be used for predictions; defaults to
-#' 95\%.
+#' 95%.
 #'
 #' @param quiet A logical indicating if warnings from `fit` should be
 #' hidden; FALSE by default. Warnings typically indicate some zero incidence,

--- a/R/fit_optim_split.R
+++ b/R/fit_optim_split.R
@@ -42,7 +42,8 @@ fit_optim_split <- function(x, window = x$timespan/4, plot = TRUE,
     out <- list(
       df = data.frame(dates = seq(dates, by = 1, length.out = sum(dfrows)),
                       mean.R2 = vector(mode = "numeric", length = sum(dfrows)),
-                      groups = factor(rep(names(res), dfrows), names(res))
+                      groups = factor(rep(names(res), dfrows), names(res)),
+                      stringsAsFactors = TRUE
                      ),
       plot = ggplot2::ggplot(),
       split = seq(dates, by = 1, length.out = length(res)),
@@ -103,7 +104,7 @@ fit_optim_split <- function(x, window = x$timespan/4, plot = TRUE,
   results <- vapply(splits.to.try, f, double(1))
 
   ## shape output
-  df <- data.frame(dates = splits.to.try, mean.R2 = results)
+  df <- data.frame(dates = splits.to.try, mean.R2 = results, stringsAsFactors = TRUE)
   split <- if (need.to.try) splits.to.try[which.max(results)] else splits.to.try
   fit <- suppressWarnings(fit(x, split = split))
   out <- list(df = df,

--- a/R/plot.R
+++ b/R/plot.R
@@ -210,7 +210,6 @@ plot.incidence <- function(x, ..., fit = NULL, stack = is.null(fit),
   ## https://github.com/tidyverse/ggplot2/issues/3873
   ## Temporary fix: changing placement to default of ggplot2::scale_x_date
   
-  df$x_dates <- df$dates + (df$interval_days / 2)
   ## x_axis <- "dates + (interval_days/2)"
   x_axis <- "dates"
   y_axis <- "counts"

--- a/R/plot.R
+++ b/R/plot.R
@@ -140,6 +140,8 @@ plot.incidence <- function(x, ..., fit = NULL, stack = is.null(fit),
   n.groups <- ncol(x$counts)
   gnames   <- group_names(x)
 
+  browser()
+  
   ## Use custom labels for usual time intervals
   if (is.null(ylab)) {
     if (is.numeric(x$interval)) {
@@ -190,16 +192,16 @@ plot.incidence <- function(x, ..., fit = NULL, stack = is.null(fit),
   ## counts the number of days within each interval.
 
   ## Adding a variable for width in ggplot
-  df$interval.days <- get_interval(x, integer = TRUE)
+  df$interval_days <- get_interval(x, integer = TRUE)
   ## if the date type is POSIXct, then the interval is actually interval seconds
   ## and needs to be converted to days
   if (inherits(df$dates, "POSIXct")) {
-    df$interval.days <- df$interval.days * 86400 # 24h * 60m * 60s
+    df$interval_days <- df$interval_days * 86400 # 24h * 60m * 60s
   }
   ## Important note: it seems safest to specify the aes() as part of the geom,
   ## not in ggplot(), as it interacts badly with some other geoms like
   ## geom_ribbon - used e.g. in projections::add_projections().
-  x_axis <- "dates + (interval.days/2)"
+  x_axis <- "dates + (interval_days/2)"
   y_axis <- "counts"
   out <- ggplot2::ggplot(df) +
     ggplot2::geom_bar(ggplot2::aes_string(
@@ -207,7 +209,7 @@ plot.incidence <- function(x, ..., fit = NULL, stack = is.null(fit),
                         y = y_axis
                         ),
                       stat = "identity",
-                      width = df$interval.days,
+                      width = df$interval_days,
                       position = stack.txt,
                       color = border,
                       alpha = alpha) +
@@ -227,7 +229,7 @@ plot.incidence <- function(x, ..., fit = NULL, stack = is.null(fit),
                                  fill  = NA,
                                  position = "stack",
                                  data = squaredf,
-                                 width = squaredf$interval.days
+                                 width = squaredf$interval_days
                                  )
     out <- out + squares
   }

--- a/R/plot.R
+++ b/R/plot.R
@@ -230,12 +230,11 @@ plot.incidence <- function(x, ..., fit = NULL, stack = is.null(fit),
   if (show_cases && stack) {
     squaredf <- df[rep(seq.int(nrow(df)), df$counts), ]
     squaredf$counts <- 1
-    squares <- ggplot2::geom_bar(ggplot2::aes_string(
+    squares <- ggplot2::geom_col(ggplot2::aes_string(
                                    x = x_axis,
                                    y = y_axis
                                    ),
                                  color = if (is.na(border)) "white" else border,
-                                 stat = "identity",
                                  fill  = NA,
                                  position = "stack",
                                  data = squaredf,

--- a/R/plot.R
+++ b/R/plot.R
@@ -140,7 +140,6 @@ plot.incidence <- function(x, ..., fit = NULL, stack = is.null(fit),
   n.groups <- ncol(x$counts)
   gnames   <- group_names(x)
 
-  browser()
   
   ## Use custom labels for usual time intervals
   if (is.null(ylab)) {
@@ -201,14 +200,25 @@ plot.incidence <- function(x, ..., fit = NULL, stack = is.null(fit),
   ## Important note: it seems safest to specify the aes() as part of the geom,
   ## not in ggplot(), as it interacts badly with some other geoms like
   ## geom_ribbon - used e.g. in projections::add_projections().
-  x_axis <- "dates + (interval_days/2)"
+
+
+  ## add mid-interval positions for x-axis
+
+  ## THIS BREAKS THE PLOT WITH ggplot2_3.3.0
+  ## See bug reports at:
+  ## https://github.com/reconhub/incidence/issues/119
+  ## https://github.com/tidyverse/ggplot2/issues/3873
+  ## Temporary fix: changing placement to default of ggplot2::scale_x_date
+  
+  df$x_dates <- df$dates + (df$interval_days / 2)
+  ## x_axis <- "dates + (interval_days/2)"
+  x_axis <- "dates"
   y_axis <- "counts"
   out <- ggplot2::ggplot(df) +
-    ggplot2::geom_bar(ggplot2::aes_string(
+    ggplot2::geom_col(ggplot2::aes_string(
                         x = x_axis,
                         y = y_axis
                         ),
-                      stat = "identity",
                       width = df$interval_days,
                       position = stack.txt,
                       color = border,

--- a/R/plot.R
+++ b/R/plot.R
@@ -136,7 +136,7 @@ plot.incidence <- function(x, ..., fit = NULL, stack = is.null(fit),
     }
   }
   ## extract data in suitable format for ggplot2
-  df <- as.data.frame(x, long = TRUE)
+  df <- as.data.frame(x, long = TRUE, stringsAsFactors = TRUE)
   n.groups <- ncol(x$counts)
   gnames   <- group_names(x)
 

--- a/man/conversions.Rd
+++ b/man/conversions.Rd
@@ -12,14 +12,18 @@
 
 as.incidence(x, ...)
 
-\method{as.incidence}{matrix}(x, dates = NULL, interval = NULL,
-  standard = TRUE, isoweeks = standard, ...)
+\method{as.incidence}{matrix}(
+  x,
+  dates = NULL,
+  interval = NULL,
+  standard = TRUE,
+  isoweeks = standard,
+  ...
+)
 
-\method{as.incidence}{data.frame}(x, dates = NULL, interval = NULL,
-  isoweeks = TRUE, ...)
+\method{as.incidence}{data.frame}(x, dates = NULL, interval = NULL, isoweeks = TRUE, ...)
 
-\method{as.incidence}{numeric}(x, dates = NULL, interval = NULL,
-  isoweeks = TRUE, ...)
+\method{as.incidence}{numeric}(x, dates = NULL, interval = NULL, isoweeks = TRUE, ...)
 }
 \arguments{
 \item{x}{An \code{incidence} object, or an object to be converted as
@@ -49,7 +53,7 @@ These functions convert \code{incidence} objects into other classes.
 \details{
 Conversion to \code{incidence} objects should only be done when the
 original dates are not available. In such case, the argument \code{x}
-should be a matrix corresponding to the \code{$counts} element of an
+should be a matrix corresponding to the \verb{$counts} element of an
 \code{incidence} object, i.e. giving counts with time intervals in rows and
 named groups in columns. In the absence of groups, a single unnamed columns
 should be given. \code{data.frame} and vectors will be coerced to a matrix.

--- a/man/fit.Rd
+++ b/man/fit.Rd
@@ -31,7 +31,7 @@ two models. If NULL, a single model is fitted. If provided, two models would
 be fitted on the time periods on either side of the split.}
 
 \item{level}{The confidence interval to be used for predictions; defaults to
-95\\%.}
+95\%.}
 
 \item{quiet}{A logical indicating if warnings from \code{fit} should be
 hidden; FALSE by default. Warnings typically indicate some zero incidence,

--- a/man/fit.Rd
+++ b/man/fit.Rd
@@ -9,8 +9,13 @@
 \usage{
 fit(x, split = NULL, level = 0.95, quiet = FALSE)
 
-fit_optim_split(x, window = x$timespan/4, plot = TRUE, quiet = TRUE,
-  separate_split = TRUE)
+fit_optim_split(
+  x,
+  window = x$timespan/4,
+  plot = TRUE,
+  quiet = TRUE,
+  separate_split = TRUE
+)
 
 \method{print}{incidence_fit}(x, ...)
 
@@ -26,7 +31,7 @@ two models. If NULL, a single model is fitted. If provided, two models would
 be fitted on the time periods on either side of the split.}
 
 \item{level}{The confidence interval to be used for predictions; defaults to
-95\%.}
+95\\%.}
 
 \item{quiet}{A logical indicating if warnings from \code{fit} should be
 hidden; FALSE by default. Warnings typically indicate some zero incidence,
@@ -51,13 +56,13 @@ For \code{fit()}, a list with the class \code{incidence_fit} (for a
 single model), or a list containing two \code{incidence_fit} objects (when
 fitting two models). \code{incidence_fit} objects contain:
 \itemize{
-\item \code{$model}: the fitted linear model
-\item \code{$info}: a list containing various information extracted from the model
+\item \verb{$model}: the fitted linear model
+\item \verb{$info}: a list containing various information extracted from the model
 (detailed further)
-\item \code{$origin}: the date corresponding to day '0'
+\item \verb{$origin}: the date corresponding to day '0'
 }
 
-The \code{$info} item is a list containing:
+The \verb{$info} item is a list containing:
 \itemize{
 \item \code{r}: the growth rate
 \item \code{r.conf}: the confidence interval of 'r'

--- a/man/get_dates.Rd
+++ b/man/get_dates.Rd
@@ -10,8 +10,7 @@ get_dates(x, ...)
 
 \method{get_dates}{default}(x, ...)
 
-\method{get_dates}{incidence}(x, position = "left", count_days = FALSE,
-  ...)
+\method{get_dates}{incidence}(x, position = "left", count_days = FALSE, ...)
 }
 \arguments{
 \item{x}{an \link{incidence} object}

--- a/man/get_fit.Rd
+++ b/man/get_fit.Rd
@@ -19,8 +19,7 @@ get_info(x, what = "r", ...)
 
 \method{get_info}{incidence_fit}(x, what = "r", ...)
 
-\method{get_info}{incidence_fit_list}(x, what = "r", groups = NULL,
-  na.rm = TRUE, ...)
+\method{get_info}{incidence_fit_list}(x, what = "r", groups = NULL, na.rm = TRUE, ...)
 }
 \arguments{
 \item{x}{an \code{incidence_fit} or \code{incidence_fit_list}

--- a/man/incidence.Rd
+++ b/man/incidence.Rd
@@ -15,23 +15,58 @@ incidence(dates, interval = 1L, ...)
 
 \method{incidence}{default}(dates, interval = 1L, ...)
 
-\method{incidence}{Date}(dates, interval = 1L, standard = TRUE,
-  groups = NULL, na_as_group = TRUE, first_date = NULL,
-  last_date = NULL, ...)
+\method{incidence}{Date}(
+  dates,
+  interval = 1L,
+  standard = TRUE,
+  groups = NULL,
+  na_as_group = TRUE,
+  first_date = NULL,
+  last_date = NULL,
+  ...
+)
 
-\method{incidence}{character}(dates, interval = 1L, standard = TRUE,
-  groups = NULL, na_as_group = TRUE, first_date = NULL,
-  last_date = NULL, ...)
+\method{incidence}{character}(
+  dates,
+  interval = 1L,
+  standard = TRUE,
+  groups = NULL,
+  na_as_group = TRUE,
+  first_date = NULL,
+  last_date = NULL,
+  ...
+)
 
-\method{incidence}{integer}(dates, interval = 1L, groups = NULL,
-  na_as_group = TRUE, first_date = NULL, last_date = NULL, ...)
+\method{incidence}{integer}(
+  dates,
+  interval = 1L,
+  groups = NULL,
+  na_as_group = TRUE,
+  first_date = NULL,
+  last_date = NULL,
+  ...
+)
 
-\method{incidence}{numeric}(dates, interval = 1L, groups = NULL,
-  na_as_group = TRUE, first_date = NULL, last_date = NULL, ...)
+\method{incidence}{numeric}(
+  dates,
+  interval = 1L,
+  groups = NULL,
+  na_as_group = TRUE,
+  first_date = NULL,
+  last_date = NULL,
+  ...
+)
 
-\method{incidence}{POSIXt}(dates, interval = 1L, standard = TRUE,
-  groups = NULL, na_as_group = TRUE, first_date = NULL,
-  last_date = NULL, ...)
+\method{incidence}{POSIXt}(
+  dates,
+  interval = 1L,
+  standard = TRUE,
+  groups = NULL,
+  na_as_group = TRUE,
+  first_date = NULL,
+  last_date = NULL,
+  ...
+)
 
 \method{print}{incidence}(x, ...)
 }
@@ -99,7 +134,7 @@ intervals labeled as 0, 3, 6, ... mean that the first bin includes days 0, 1
 and 2, the second interval includes 3, 4 and 5 etc.
 }
 \details{
-For details about the \code{incidence class}, see the dedicated
+For details about the \verb{incidence class}, see the dedicated
 vignette:\cr \code{vignette("incidence_class", package = "incidence")}
 }
 \note{

--- a/man/plot.incidence.Rd
+++ b/man/plot.incidence.Rd
@@ -9,11 +9,22 @@
 \alias{make_breaks}
 \title{Plot function for incidence objects}
 \usage{
-\method{plot}{incidence}(x, ..., fit = NULL, stack = is.null(fit),
-  color = "black", border = NA, col_pal = incidence_pal1,
-  alpha = 0.7, xlab = "", ylab = NULL,
-  labels_week = !is.null(x$weeks), labels_iso = !is.null(x$isoweeks),
-  show_cases = FALSE, n_breaks = 6)
+\method{plot}{incidence}(
+  x,
+  ...,
+  fit = NULL,
+  stack = is.null(fit),
+  color = "black",
+  border = NA,
+  col_pal = incidence_pal1,
+  alpha = 0.7,
+  xlab = "",
+  ylab = NULL,
+  labels_week = !is.null(x$weeks),
+  labels_iso = !is.null(x$isoweeks),
+  show_cases = FALSE,
+  n_breaks = 6
+)
 
 add_incidence_fit(p, x, col_pal = incidence_pal1)
 
@@ -31,7 +42,7 @@ make_breaks(x, n_breaks = 6L, labels_week = TRUE)
 
 \item{...}{arguments passed to \code{\link[ggplot2:scale_x_date]{ggplot2::scale_x_date()}},
 \code{\link[ggplot2:scale_x_datetime]{ggplot2::scale_x_datetime()}}, or \code{\link[ggplot2:scale_x_continuous]{ggplot2::scale_x_continuous()}}, depending
-on how the \code{$date} element is stored in the incidence object.}
+on how the \verb{$date} element is stored in the incidence object.}
 
 \item{fit}{An 'incidence_fit' object as returned by \code{\link[=fit]{fit()}}.}
 

--- a/man/subset.Rd
+++ b/man/subset.Rd
@@ -7,8 +7,7 @@
 \alias{[.incidence}
 \title{Subsetting 'incidence' objects}
 \usage{
-\method{subset}{incidence}(x, ..., from = min(x$dates),
-  to = max(x$dates), groups = TRUE)
+\method{subset}{incidence}(x, ..., from = min(x$dates), to = max(x$dates), groups = TRUE)
 
 \method{[}{incidence}(x, i, j)
 }

--- a/tests/testthat/test-conversions.R
+++ b/tests/testthat/test-conversions.R
@@ -9,13 +9,13 @@ test_that("as.data.frame works", {
   fac <- factor(c(1, 2, 3, 3, 3, 3, 1))
   one_group <- rep("a", 7)
 
-   
+
   i_group_df <- data.frame(
          dates = c(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L),
             "1" = c(1L, 0L, 0L, 0L, 0L, 0L, 0L, 1L),
             "2" = c(0L, 1L, 0L, 0L, 0L, 0L, 0L, 0L),
             "3" = c(0L, 0L, 2L, 1L, 0L, 1L, 0L, 0L),
-            check.names = FALSE
+            check.names = FALSE, stringsAsFactors = TRUE
   )
   # one group
   i_og_df <- i_group_df[, 1, drop = FALSE]
@@ -28,7 +28,7 @@ test_that("as.data.frame works", {
                    0L, 0L, 0L, 2L, 1L, 0L, 1L, 0L, 0L),
         groups = as.factor(c("1", "1", "1", "1", "1", "1", "1", "1", "2", "2",
                              "2", "2", "2", "2", "2", "2", "3", "3", "3", "3",
-                             "3", "3", "3", "3"))
+                             "3", "3", "3", "3")), stringsAsFactors = TRUE
   )
 
   i <- incidence(dat, groups = fac)


### PR DESCRIPTION
This is a patch for `plot.incidence` which is currently broken due to this [issue in ggplot2](https://github.com/tidyverse/ggplot2/issues/3873), as described in https://github.com/reconhub/incidence/issues/119.

### Outline of patch

* x-axis dates are now the original dates, no longer the middle of the corresponding interval
* `geom_col` replaces `geom_bar(..., stat = "indentity"`)
* version: 1.7.0 -> 1.7.1

This fixes the issue on:

```r
> R.version
               _                           
platform       x86_64-pc-linux-gnu         
arch           x86_64                      
os             linux-gnu                   
system         x86_64, linux-gnu           
status                                     
major          3                           
minor          6.3                         
year           2020                        
month          02                          
day            29                          
svn rev        77875                       
language       R                           
version.string R version 3.6.3 (2020-02-29)
nickname       Holding the Windsock        
```


### Unrelated stuff that came up

I get unrelated warnings re documentation (see below) which I ignored as probably unrelated to this patch.

```r
❯ checking Rd files ... WARNING
  prepare_Rd: man/fit.Rd:36: unknown macro '\item'
  prepare_Rd: man/fit.Rd:40: unknown macro '\item'
  prepare_Rd: man/fit.Rd:43: unknown macro '\item'
  prepare_Rd: man/fit.Rd:46: unknown macro '\item'
  prepare_Rd: man/fit.Rd:52: unknown macro '\item'
  prepare_Rd: man/fit.Rd:54: unexpected section header '\value'
  prepare_Rd: man/fit.Rd:94: unexpected section header '\description'
  prepare_Rd: man/fit.Rd:107: unexpected section header '\examples'
  prepare_Rd: man/fit.Rd:152: unexpected section header '\seealso'
  prepare_Rd: man/fit.Rd:157: unexpected section header '\author'
  prepare_Rd: man/fit.Rd:161: unexpected END_OF_INPUT '
  '
  checkRd: (5) fit.Rd:0-162: Must have a \description

❯ checking Rd \usage sections ... WARNING
  Undocumented arguments in documentation object 'fit'
    ‘quiet’ ‘window’ ‘plot’ ‘separate_split’ ‘...’
  
  Functions with \usage entries need to have the appropriate \alias
  entries, and all their arguments documented.
  The \usage entries must correspond to syntactically valid R code.
  See chapter ‘Writing R documentation files’ in the ‘Writing R
  Extensions’ manual.
``` 