### PR TITLE
Release to CRAN

### DIFF
--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,2 @@
-This package was submitted to CRAN on 2020-03-24.
-Once it is accepted, delete this file and tag the release (commit 2b064be29e).
+This package was submitted to CRAN on 2020-03-25.
+Once it is accepted, delete this file and tag the release (commit 0fd770e413).

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,0 +1,2 @@
+This package was submitted to CRAN on 2020-03-24.
+Once it is accepted, delete this file and tag the release (commit 2b064be29e).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,6 @@ Package: incidence
 Type: Package
 Title: Compute, Handle, Plot and Model Incidence of Dated Events
 Version: 1.7.1
-Date: 2019-03-14
 Authors@R: c(
   person("Thibaut", "Jombart", role = c("aut"), email = "thibautjombart@gmail.com"), 
   person("Zhian N.", "Kamvar", role = c("aut", "cre"), email = "zkamvar@gmail.com",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,14 +1,16 @@
 ## Notes to CRAN
 
-This fixes tests failing on R 3.6.0 due to the RNG bugfix.
+This fixes a bug caused by the new ggplot2 release
+
+All reverse dependencies have been checked with none displaying worse checks
 
 ## Test environments
 
-* ubuntu 16.04, R 3.5.3
-* MacOS 10.14.2, R 3.5.3
+* ubuntu 16.04, R 3.6.3
+* MacOS 10.14.2, R 3.6.3
 * ubuntu 14.04, (on travis-ci), 
-* ubuntu 14.04 (on travis-ci), R devel [2019-03-13 r76228]
-* win-builder (devel [2019-03-11 r76226] and release)
+* ubuntu 14.04 (on travis-ci), R devel
+* win-builder (devel and release)
 
 ## R CMD check results
 


### PR DESCRIPTION
This releases the bugfix 1.7.1 to cran.

Once I have received a confirmation email, I will tag the commit and push to master